### PR TITLE
fix: preserve utf8 multibyte characters split across chunks in XmlTransformStream

### DIFF
--- a/src/XmlTransformStream.ts
+++ b/src/XmlTransformStream.ts
@@ -55,7 +55,7 @@ export default class XmlTransformStream extends TransformStream<Uint8Array, Uint
           // Guard anyway in case someone uses this TransformStream with an unexpected stream type
           throw new Error('Received non-Uint8Array chunk');
         }
-        let chunkAsString = textDecoder.decode(chunk);
+        let chunkAsString = textDecoder.decode(chunk, { stream: true });
 
         // Whenever a chunk is added, it is added to the currently processing chunk, and an attempt is made to
         // parse it.
@@ -68,6 +68,9 @@ export default class XmlTransformStream extends TransformStream<Uint8Array, Uint
         });
       },
       async flush(controller: TransformStreamDefaultController<Uint8Array>) {
+        // Flush and append any buffered bytes in the decoder (e.g incomplete multibyte chars)
+        xmlStreamerContext.append(textDecoder.decode());
+
         xmlStreamerContext.flush(true);
 
         await dispatchCompleteTopLevelChildren(chunk => {


### PR DESCRIPTION
Fixes an issue where multibyte utf8 characters like ö or emojis would get corrupted if their byte sequence was split across multiple stream chunks. 

Previously the `XmlTransformStream` used `textDecoder.decode(chunk)` per chunk. If a multibyte char was split across chunks the decoder would treat an incomplete sequence as invalid and replace it with a replacement char `U+FFFD (�)`

The fix is to call `textDecoder.decode(chunk, { stream: true })`  which tells the decoder to buffer incomplete sequences between chunks.  
The final `textDecoder.decode()` in flush emits any buffered sequences

Before: `ö��ö`
After: `ööö`

links:
- [WHATWG Encoding spec](https://encoding.spec.whatwg.org/#textdecoder)
- [MDN TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode#options)
<img width="807" height="241" alt="image" src="https://github.com/user-attachments/assets/d6ff6820-7b1e-4591-94b1-4c850c8c5628" />
<img width="752" height="206" alt="Arc 2025-08-26 10 22 26 PM" src="https://github.com/user-attachments/assets/08adfcd0-a22f-489a-a8be-07b1ab33ccdf" />

